### PR TITLE
Updated manager.py, changed 'async' argument name

### DIFF
--- a/asterisk/manager.py
+++ b/asterisk/manager.py
@@ -538,7 +538,7 @@ class Manager(object):
 
         return response
 
-    def originate(self, channel, exten, context='', priority='', timeout='', caller_id='', async=False, account='', variables={}):
+    def originate(self, channel, exten, context='', priority='', timeout='', caller_id='', async_=False, account='', variables={}):
         """Originate a call"""
 
         cdict = {'Action': 'Originate'}
@@ -552,7 +552,7 @@ class Manager(object):
             cdict['Timeout'] = timeout
         if caller_id:
             cdict['CallerID'] = caller_id
-        if async:
+        if async_:
             cdict['Async'] = 'yes'
         if account:
             cdict['Account'] = account


### PR DESCRIPTION
Newer versions of Python didn't like the argument name 'async' because it is now used elsewhere. The argument name just had to be changed to something else. This tweak allows me to "import asterisk.manager" now without throwing errors in Python 3.8.